### PR TITLE
extend using clause for DetourContext

### DIFF
--- a/Hooks/ActorHooks.cs
+++ b/Hooks/ActorHooks.cs
@@ -25,12 +25,12 @@ namespace Celeste.Mod.GravityHelper.Hooks
             IL.Celeste.Actor.TrySquishWiggle_CollisionData_int_int += Actor_TrySquishWiggle_CollisionData_int_int;
 
             // we need to run this after MaddieHelpingHand to ensure both UDJT types are handled
-            using (new DetourContext {After = {"MaxHelpingHand"}})
+            using (new DetourContext {After = {"MaxHelpingHand"}}) {
                 IL.Celeste.Actor.MoveVExact += Actor_MoveVExact;
-
-            On.Celeste.Actor.MoveV += Actor_MoveV;
-            On.Celeste.Actor.MoveVExact += Actor_MoveVExact;
-            On.Celeste.Actor.IsRiding_JumpThru += Actor_IsRiding_JumpThru;
+                On.Celeste.Actor.MoveV += Actor_MoveV;
+                On.Celeste.Actor.MoveVExact += Actor_MoveVExact;
+                On.Celeste.Actor.IsRiding_JumpThru += Actor_IsRiding_JumpThru;
+            }
         }
 
         public static void Unload()

--- a/Hooks/PlayerHooks.cs
+++ b/Hooks/PlayerHooks.cs
@@ -92,27 +92,28 @@ namespace Celeste.Mod.GravityHelper.Hooks
             On.Celeste.Player.Update += Player_Update;
             On.Celeste.Player.WindMove += Player_WindMove;
 
-            using (new DetourContext { Before = { "MaxHelpingHand", "SpringCollab2020" }})
+            using (new DetourContext { Before = { "MaxHelpingHand", "SpringCollab2020" }}) {
                 hook_Player_orig_Update = new ILHook(ReflectionCache.Player_OrigUpdate, Player_orig_Update);
 
-            hook_Player_DashCoroutine = new ILHook(ReflectionCache.Player_DashCoroutine.GetStateMachineTarget(), Player_DashCoroutine);
-            hook_Player_IntroJumpCoroutine = new ILHook(ReflectionCache.Player_IntroJumpCoroutine.GetStateMachineTarget(), Player_IntroJumpCoroutine);
-            hook_Player_PickupCoroutine = new ILHook(ReflectionCache.Player_PickupCoroutine.GetStateMachineTarget(), Player_PickupCoroutine);
-            hook_Player_orig_UpdateSprite = new ILHook(ReflectionCache.Player_OrigUpdateSprite, Player_orig_UpdateSprite);
-            hook_Player_orig_WallJump = new ILHook(ReflectionCache.Player_OrigWallJump, Player_orig_WallJump);
-            hook_Player_get_CanUnDuck = new ILHook(ReflectionCache.Player_CanUnDuck, Player_get_CanUnDuck);
-            hook_Player_get_CameraTarget = new ILHook(ReflectionCache.Player_CameraTarget, Player_get_CameraTarget);
+                hook_Player_DashCoroutine = new ILHook(ReflectionCache.Player_DashCoroutine.GetStateMachineTarget(), Player_DashCoroutine);
+                hook_Player_IntroJumpCoroutine = new ILHook(ReflectionCache.Player_IntroJumpCoroutine.GetStateMachineTarget(), Player_IntroJumpCoroutine);
+                hook_Player_PickupCoroutine = new ILHook(ReflectionCache.Player_PickupCoroutine.GetStateMachineTarget(), Player_PickupCoroutine);
+                hook_Player_orig_UpdateSprite = new ILHook(ReflectionCache.Player_OrigUpdateSprite, Player_orig_UpdateSprite);
+                hook_Player_orig_WallJump = new ILHook(ReflectionCache.Player_OrigWallJump, Player_orig_WallJump);
+                hook_Player_get_CanUnDuck = new ILHook(ReflectionCache.Player_CanUnDuck, Player_get_CanUnDuck);
+                hook_Player_get_CameraTarget = new ILHook(ReflectionCache.Player_CameraTarget, Player_get_CameraTarget);
 
-            // we assume the first .ctor method that accepts (string) is Sprite.OnFrameChange +=
-            var spriteOnFrameChange = typeof(Player).GetRuntimeMethods().FirstOrDefault(m =>
-            {
-                if (!m.Name.Contains(".ctor")) return false;
-                var parameters = m.GetParameters();
-                return parameters.Length == 1 && parameters[0].ParameterType == typeof(string);
-            });
+                // we assume the first .ctor method that accepts (string) is Sprite.OnFrameChange +=
+                var spriteOnFrameChange = typeof(Player).GetRuntimeMethods().FirstOrDefault(m =>
+                {
+                    if (!m.Name.Contains(".ctor")) return false;
+                    var parameters = m.GetParameters();
+                    return parameters.Length == 1 && parameters[0].ParameterType == typeof(string);
+                });
 
-            if (spriteOnFrameChange != null)
-                hook_Player_ctor_OnFrameChange = new ILHook(spriteOnFrameChange, Player_ctor_OnFrameChange);
+                if (spriteOnFrameChange != null)
+                    hook_Player_ctor_OnFrameChange = new ILHook(spriteOnFrameChange, Player_ctor_OnFrameChange);
+            }
         }
 
         public static void Unload()


### PR DESCRIPTION
This fix extends DetourContext clause to include all other hooks that come after it. This PR fixes the issue where core branch [crashes on SJ ](https://discord.com/channels/403698615446536203/908809001834274887/1142928686597812234).
This soudn't change the behavor of stabe because of the [DetourContext bug](https://discord.com/channels/403698615446536203/429775439423209472/1139832733510676602).