### PR TITLE
Fix inconsistent cornerboost problem of inversion block

### DIFF
--- a/Loenn/entities/inversionBlock.lua
+++ b/Loenn/entities/inversionBlock.lua
@@ -32,6 +32,7 @@ local placementData = helpers.createPlacementData('2', {
     blockOneUse = false,
     showEdgeIndicators = true,
     legacyFallBehavior = false,
+    climbjumpType = 0,
 })
 
 local inversionBlock = {
@@ -48,6 +49,7 @@ local inversionBlock = {
         "fallType", "climbFall", "endFallOnSolidTiles",
         "tiletype", "sound",
         "autotile", "showEdgeIndicators", "defaultToController", "legacyFallBehavior",
+        "climbjumpType",
     },
     fieldInformation = function() return {
         leftGravityType = consts.fieldInformation.gravityType(0,1,2),
@@ -62,6 +64,9 @@ local inversionBlock = {
         },
         refillRespawnTime = {
             fieldType = "number",
+        },
+        climbjumpType = {
+            fieldType = "integer",
         }
     } end,
     placements = {

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -369,6 +369,7 @@ entities.GravityHelper/InversionBlock.attributes.description.refillOneUse=Whethe
 entities.GravityHelper/InversionBlock.attributes.description.blockOneUse=Whether the block has a single use and will be disabled once triggered. Defaults to false.
 entities.GravityHelper/InversionBlock.attributes.description.showEdgeIndicators=Whether to show the coloured edge indicators. Defaults to true.
 entities.GravityHelper/InversionBlock.attributes.description.legacyFallBehavior=Prior to Gravity Helper 1.2.17, jumping on an inversion block about to fall\nwould cause it to shake for the maximum amount of time rather than honouring the\n"player has jumped therefore immediately fall" behaviour with regular falling blocks.\n\nEnabling this reverts to the old behaviour, and is not recommended.
+entities.GravityHelper/InversionBlock.attributes.description.climbjumpType=Whether walljump or climbjump when player climb jumping into the otherside \nwith the same direction holding. If equal to 0 (default) it will climbjump when speed/retainedspeed \ngreater than 130 (walljumpXSpeed) and walljump otherwise; if equal to 1 it will always walljump \n(which is legacy behavior); if equal to 2 it will always climbjump.
 
 # Force Load Gravity Controller
 entities.GravityHelper/ForceLoadGravityController.placements.name.normal=Force Load Gravity Controller

--- a/Source/Hooks/PlayerHooks.cs
+++ b/Source/Hooks/PlayerHooks.cs
@@ -1295,9 +1295,9 @@ internal static class PlayerHooks
         var oldFacing = self.Facing;
         var handled = handleInversionBlocks(self);
 
-        if (handled && oldFacing == self.Facing)
+        if (oldFacing == self.Facing && handled == 1)
         {
-            // if we were warped and kept the same facing, we shouldn't lose stamina
+            // walljump when ClimbjumpType == 1 or ClimbjumpType == 0 and speed is not enough
             self.WallJump((int)self.Facing);
         }
         else
@@ -1432,15 +1432,16 @@ internal static class PlayerHooks
         orig(self, particles, playsfx);
     }
 
-    private static bool handleInversionBlocks(Player self)
+    private static int handleInversionBlocks(Player self)
     {
         foreach (InversionBlock block in self.Scene.Tracker.GetEntities<InversionBlock>())
         {
-            if (block.TryHandlePlayer(self))
-                return true;
+            var temp = block.TryHandlePlayer(self);
+            if (temp != 0)
+                return temp;
         }
 
-        return false;
+        return 0;
     }
 
     private static bool Player_JumpThruBoostBlockedCheck(On.Celeste.Player.orig_JumpThruBoostBlockedCheck orig, Player self)


### PR DESCRIPTION
This PR should (probably) fix the issue [Inversion block climb jumps are inconsistent](https://github.com/swoolcock/GravityHelper/issues/84).

The main change of inversion block is that a new option of inversion block called ClimbjumpType is added. It should only take three integer value 0,1,2.
1 is the legacy behavior.
In 2, the player will always climbjump when the player is warped to the otherside, regardless of whether the player is pushing into the block.
In 0, the player will climbjump if the player is pushing into the block and the player's speed/retained speed is greater than 130 (walljumpXspeed), and walljump if the speed is not enough (the player will still climbjump if the player is not pushing into the block).